### PR TITLE
[pom] Remove argument for release to run release as parent does it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,14 +113,6 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <configuration>
-          <arguments>-Prelease</arguments>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
         <version>3.5</version>
         <configuration>


### PR DESCRIPTION
the argument was needed long ago but since thing the release plugin
already sets using a standard way to kick off the profile for release.