### PR TITLE
Finialize migration to junit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,12 +198,6 @@
       <version>31.1-jre</version>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <version>5.9.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>5.9.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,13 @@
       <version>5.9.0</version>
       <scope>test</scope>
     </dependency>
+    <!-- Needed still for Plexus Test Case code borrowed from Maven as we don't want to modify their library -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>5.9.0</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Commons Patches due to maven legacy usage and vulnerabilities in many cases -->
     <dependency>

--- a/src/test/java/org/mybatis/maven/mvnmigrate/AbstractMigrateTestCase.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/AbstractMigrateTestCase.java
@@ -18,28 +18,32 @@ package org.mybatis.maven.mvnmigrate;
 import java.io.File;
 
 import org.apache.ibatis.migration.commands.InitializeCommand;
-import org.junit.Rule;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+@ExtendWith(MojoExtension.class)
 public abstract class AbstractMigrateTestCase {
 
-  // TODO There is no BaseDir for Junit4 version. Does not seem to be needed and maven site points to other method call
-  // that doesn't exist.
-  // Leave this for now until we can determine this is needed or not.
-  // protected File testPom = new File(getBasedir(), "src/test/resources/unit/basic-test/basic-test-plugin-config.xml");
+  @RegisterExtension
+  private static MojoExtension extension = new MojoExtension();
+
+  protected AbstractMojoTestCase testCase;
+
   protected File testPom = new File("src/test/resources/unit/basic-test/basic-test-plugin-config.xml");
 
-  @Rule
-  public MybatisMojoRule rule = new MybatisMojoRule();
+  public AbstractMigrateTestCase() {
+    testCase = extension.testCase;
+  }
 
   @SuppressWarnings("unchecked")
   protected void initEnvironment() throws Exception {
-    AbstractCommandMojo<InitializeCommand> mojo = (AbstractCommandMojo<InitializeCommand>) rule.lookupMojo("init",
+    AbstractCommandMojo<InitializeCommand> mojo = (AbstractCommandMojo<InitializeCommand>) testCase.lookupMojo("init",
         testPom);
     Assertions.assertNotNull(mojo);
 
     final File newRep = new File("target/init");
-    rule.setVariableValueToObject(mojo, "repository", newRep);
+    testCase.setVariableValueToObject(mojo, "repository", newRep);
     mojo.execute();
     Assertions.assertTrue(newRep.exists());
   }

--- a/src/test/java/org/mybatis/maven/mvnmigrate/AbstractMojoTestCase.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/AbstractMojoTestCase.java
@@ -1,0 +1,730 @@
+/*
+ *    Copyright 2010-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.maven.mvnmigrate;
+
+import com.google.inject.Module;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.commons.io.input.XmlStreamReader;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.factory.ArtifactFactory;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.DefaultMavenExecutionResult;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenExecutionResult;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.internal.MojoDescriptorCreator;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.monitor.logging.DefaultLog;
+import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.PluginParameterExpressionEvaluator;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.Parameter;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugin.descriptor.PluginDescriptorBuilder;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugin.testing.ConfigurationException;
+import org.apache.maven.plugin.testing.ResolverExpressionEvaluatorStub;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.DefaultContainerConfiguration;
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusConstants;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.PlexusTestCase;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.ComponentConfigurator;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.component.repository.ComponentDescriptor;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.logging.LoggerManager;
+import org.codehaus.plexus.util.InterpolationFilterReader;
+import org.codehaus.plexus.util.ReaderFactory;
+import org.codehaus.plexus.util.ReflectionUtils;
+import org.codehaus.plexus.util.StringUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
+
+/**
+ * Mybatis: Borrowed from 'https://github.com/apache/maven-plugin-testing/blob/master/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/AbstractMojoTestCase.java'
+ * Reason: Too restrictive to use directly for junit 5.  Only changes were to apply imports.
+ * Git: From commit 7d6518b
+ */
+
+/**
+ * TODO: add a way to use the plugin POM for the lookup so that the user doesn't have to provide the a:g:v:goal as the
+ * role hint for the mojo lookup. TODO: standardize the execution of the mojo and looking at the results, but could
+ * simply have a template method for verifying the state of the mojo post execution TODO: need a way to look at the
+ * state of the mojo without adding getters, this could be where we finally specify the expressions which extract values
+ * from the mojo. TODO: create a standard directory structure for picking up POMs to make this even easier, we really
+ * just need a testing descriptor and make this entirely declarative!
+ *
+ * @author jesse
+ */
+public abstract class AbstractMojoTestCase extends PlexusTestCase {
+  private static final DefaultArtifactVersion MAVEN_VERSION;
+
+  static {
+    DefaultArtifactVersion version = null;
+    String path = "/META-INF/maven/org.apache.maven/maven-core/pom.properties";
+
+    try (InputStream is = AbstractMojoTestCase.class.getResourceAsStream(path)) {
+      Properties properties = new Properties();
+      if (is != null) {
+        properties.load(is);
+      }
+      String property = properties.getProperty("version");
+      if (property != null) {
+        version = new DefaultArtifactVersion(property);
+      }
+    } catch (IOException e) {
+      // odd, where did this come from
+    }
+    MAVEN_VERSION = version;
+  }
+
+  private ComponentConfigurator configurator;
+
+  private PlexusContainer container;
+
+  private Map<String, MojoDescriptor> mojoDescriptors;
+
+  /*
+   * for the harness I think we have decided against going the route of using the maven project builder. instead I think
+   * we are going to try and make an instance of the localrespository and assign that to either the project stub or into
+   * the mojo directly with injection...not sure yet though.
+   */
+  // private MavenProjectBuilder projectBuilder;
+  @Override
+  protected void setUp() throws Exception {
+    assertTrue("Maven 3.2.4 or better is required",
+        MAVEN_VERSION == null || new DefaultArtifactVersion("3.2.3").compareTo(MAVEN_VERSION) < 0);
+
+    configurator = getContainer().lookup(ComponentConfigurator.class, "basic");
+    Context context = container.getContext();
+    Map<Object, Object> map = context.getContextData();
+
+    try (InputStream is = getClass().getResourceAsStream("/" + getPluginDescriptorLocation());
+        Reader reader = new BufferedReader(new XmlStreamReader(is));
+        InterpolationFilterReader interpolationReader = new InterpolationFilterReader(reader, map, "${", "}")) {
+
+      PluginDescriptor pluginDescriptor = new PluginDescriptorBuilder().build(interpolationReader);
+
+      Artifact artifact = lookup(ArtifactFactory.class).createBuildArtifact(pluginDescriptor.getGroupId(),
+          pluginDescriptor.getArtifactId(), pluginDescriptor.getVersion(), ".jar");
+
+      artifact.setFile(getPluginArtifactFile());
+      pluginDescriptor.setPluginArtifact(artifact);
+      // noinspection ArraysAsListWithZeroOrOneArgument
+      pluginDescriptor.setArtifacts(Arrays.asList(artifact));
+
+      for (ComponentDescriptor<?> desc : pluginDescriptor.getComponents()) {
+        getContainer().addComponentDescriptor(desc);
+      }
+
+      mojoDescriptors = new HashMap<>();
+      for (MojoDescriptor mojoDescriptor : pluginDescriptor.getMojos()) {
+        mojoDescriptors.put(mojoDescriptor.getGoal(), mojoDescriptor);
+      }
+    }
+  }
+
+  /**
+   * Returns best-effort plugin artifact file.
+   * <p>
+   * First, attempts to determine parent directory of META-INF directory holding the plugin descriptor. If META-INF
+   * parent directory cannot be determined, falls back to test basedir.
+   */
+  private File getPluginArtifactFile() throws IOException {
+    final String pluginDescriptorLocation = getPluginDescriptorLocation();
+    final URL resource = getClass().getResource("/" + pluginDescriptorLocation);
+
+    File file = null;
+
+    // attempt to resolve relative to META-INF/maven/plugin.xml first
+    if (resource != null) {
+      if ("file".equalsIgnoreCase(resource.getProtocol())) {
+        String path = resource.getPath();
+        if (path.endsWith(pluginDescriptorLocation)) {
+          file = new File(path.substring(0, path.length() - pluginDescriptorLocation.length()));
+        }
+      } else if ("jar".equalsIgnoreCase(resource.getProtocol())) {
+        // TODO is there a helper for this somewhere?
+        try {
+          URL jarfile = new URL(resource.getPath());
+          if ("file".equalsIgnoreCase(jarfile.getProtocol())) {
+            String path = jarfile.getPath();
+            if (path.endsWith(pluginDescriptorLocation)) {
+              file = new File(path.substring(0, path.length() - pluginDescriptorLocation.length() - 2));
+            }
+          }
+        } catch (MalformedURLException e) {
+          // not jar:file:/ URL, too bad
+        }
+      }
+    }
+
+    // fallback to test project basedir if couldn't resolve relative to META-INF/maven/plugin.xml
+    if (file == null || !file.exists()) {
+      file = new File(getBasedir());
+    }
+
+    return file.getCanonicalFile();
+  }
+
+  protected InputStream getPublicDescriptorStream() throws Exception {
+    return Files.newInputStream(new File(getPluginDescriptorPath()).toPath());
+  }
+
+  protected String getPluginDescriptorPath() {
+    return getBasedir() + "/target/classes/META-INF/maven/plugin.xml";
+  }
+
+  protected String getPluginDescriptorLocation() {
+    return "META-INF/maven/plugin.xml";
+  }
+
+  @Override
+  protected void setupContainer() {
+    ContainerConfiguration cc = setupContainerConfiguration();
+    try {
+      List<Module> modules = new ArrayList<>();
+      addGuiceModules(modules);
+      container = new DefaultPlexusContainer(cc, modules.toArray(new Module[0]));
+    } catch (PlexusContainerException e) {
+      e.printStackTrace();
+      fail("Failed to create plexus container.");
+    }
+  }
+
+  /**
+   * @since 3.0.0
+   */
+  @SuppressWarnings("EmptyMethod")
+  protected void addGuiceModules(List<Module> modules) {
+    // no custom guice modules by default
+  }
+
+  protected ContainerConfiguration setupContainerConfiguration() {
+    return new DefaultContainerConfiguration()
+        .setClassWorld(new ClassWorld("plexus.core", Thread.currentThread().getContextClassLoader()))
+        .setClassPathScanning(PlexusConstants.SCANNING_INDEX).setAutoWiring(true).setName("maven");
+  }
+
+  @Override
+  protected PlexusContainer getContainer() {
+    if (container == null) {
+      setupContainer();
+    }
+
+    return container;
+  }
+
+  /**
+   * Lookup the mojo leveraging the subproject pom
+   *
+   * @param goal
+   * @param pluginPom
+   * @return a Mojo instance
+   * @throws Exception
+   */
+  protected Mojo lookupMojo(String goal, String pluginPom) throws Exception {
+    return lookupMojo(goal, new File(pluginPom));
+  }
+
+  /**
+   * Lookup an empty mojo
+   *
+   * @param goal
+   * @param pluginPom
+   * @return a Mojo instance
+   * @throws Exception
+   */
+  protected Mojo lookupEmptyMojo(String goal, String pluginPom) throws Exception {
+    return lookupEmptyMojo(goal, new File(pluginPom));
+  }
+
+  /**
+   * Lookup the mojo leveraging the actual subprojects pom
+   *
+   * @param goal
+   * @param pom
+   * @return a Mojo instance
+   * @throws Exception
+   */
+  protected Mojo lookupMojo(String goal, File pom) throws Exception {
+    File pluginPom = new File(getBasedir(), "pom.xml");
+
+    Xpp3Dom pluginPomDom = Xpp3DomBuilder.build(ReaderFactory.newXmlReader(pluginPom));
+
+    String artifactId = pluginPomDom.getChild("artifactId").getValue();
+
+    String groupId = resolveFromRootThenParent(pluginPomDom, "groupId");
+
+    String version = resolveFromRootThenParent(pluginPomDom, "version");
+
+    PlexusConfiguration pluginConfiguration = extractPluginConfiguration(artifactId, pom);
+
+    return lookupMojo(groupId, artifactId, version, goal, pluginConfiguration);
+  }
+
+  /**
+   * Lookup the mojo leveraging the actual subprojects pom
+   *
+   * @param goal
+   * @param pom
+   * @return a Mojo instance
+   * @throws Exception
+   */
+  protected Mojo lookupEmptyMojo(String goal, File pom) throws Exception {
+    File pluginPom = new File(getBasedir(), "pom.xml");
+
+    Xpp3Dom pluginPomDom = Xpp3DomBuilder.build(ReaderFactory.newXmlReader(pluginPom));
+
+    String artifactId = pluginPomDom.getChild("artifactId").getValue();
+
+    String groupId = resolveFromRootThenParent(pluginPomDom, "groupId");
+
+    String version = resolveFromRootThenParent(pluginPomDom, "version");
+
+    return lookupMojo(groupId, artifactId, version, goal, null);
+  }
+
+  /*
+   * protected Mojo lookupMojo( String groupId, String artifactId, String version, String goal, File pom ) throws
+   * Exception { PlexusConfiguration pluginConfiguration = extractPluginConfiguration( artifactId, pom ); return
+   * lookupMojo( groupId, artifactId, version, goal, pluginConfiguration ); }
+   */
+  /**
+   * lookup the mojo while we have all of the relavent information
+   *
+   * @param groupId
+   * @param artifactId
+   * @param version
+   * @param goal
+   * @param pluginConfiguration
+   * @return a Mojo instance
+   * @throws Exception
+   */
+  protected Mojo lookupMojo(String groupId, String artifactId, String version, String goal,
+      PlexusConfiguration pluginConfiguration) throws Exception {
+    validateContainerStatus();
+
+    // pluginkey = groupId : artifactId : version : goal
+
+    Mojo mojo = lookup(Mojo.class, groupId + ":" + artifactId + ":" + version + ":" + goal);
+
+    LoggerManager loggerManager = getContainer().lookup(LoggerManager.class);
+
+    Log mojoLogger = new DefaultLog(loggerManager.getLoggerForComponent(Mojo.ROLE));
+
+    mojo.setLog(mojoLogger);
+
+    if (pluginConfiguration != null) {
+      /*
+       * requires v10 of plexus container for lookup on expression evaluator ExpressionEvaluator evaluator =
+       * (ExpressionEvaluator) getContainer().lookup( ExpressionEvaluator.ROLE, "stub-evaluator" );
+       */
+      ExpressionEvaluator evaluator = new ResolverExpressionEvaluatorStub();
+
+      configurator.configureComponent(mojo, pluginConfiguration, evaluator, getContainer().getContainerRealm());
+    }
+
+    return mojo;
+  }
+
+  /**
+   *
+   * @param project
+   * @param goal
+   * @return
+   * @throws Exception
+   * @since 2.0
+   */
+  protected Mojo lookupConfiguredMojo(MavenProject project, String goal) throws Exception {
+    return lookupConfiguredMojo(newMavenSession(project), newMojoExecution(goal));
+  }
+
+  /**
+   *
+   * @param session
+   * @param execution
+   * @return
+   * @throws Exception
+   * @throws ComponentConfigurationException
+   * @since 2.0
+   */
+  protected Mojo lookupConfiguredMojo(MavenSession session, MojoExecution execution)
+      throws Exception, ComponentConfigurationException {
+    MavenProject project = session.getCurrentProject();
+    MojoDescriptor mojoDescriptor = execution.getMojoDescriptor();
+
+    Mojo mojo = (Mojo) lookup(mojoDescriptor.getRole(), mojoDescriptor.getRoleHint());
+
+    ExpressionEvaluator evaluator = new PluginParameterExpressionEvaluator(session, execution);
+
+    Xpp3Dom configuration = null;
+    Plugin plugin = project.getPlugin(mojoDescriptor.getPluginDescriptor().getPluginLookupKey());
+    if (plugin != null) {
+      configuration = (Xpp3Dom) plugin.getConfiguration();
+    }
+    if (configuration == null) {
+      configuration = new Xpp3Dom("configuration");
+    }
+    configuration = Xpp3Dom.mergeXpp3Dom(configuration, execution.getConfiguration());
+
+    PlexusConfiguration pluginConfiguration = new XmlPlexusConfiguration(configuration);
+
+    if (mojoDescriptor.getComponentConfigurator() != null) {
+      configurator = getContainer().lookup(ComponentConfigurator.class, mojoDescriptor.getComponentConfigurator());
+    }
+
+    configurator.configureComponent(mojo, pluginConfiguration, evaluator, getContainer().getContainerRealm());
+
+    return mojo;
+  }
+
+  /**
+   *
+   * @param project
+   * @return
+   * @since 2.0
+   */
+  protected MavenSession newMavenSession(MavenProject project) {
+    MavenExecutionRequest request = new DefaultMavenExecutionRequest();
+    MavenExecutionResult result = new DefaultMavenExecutionResult();
+
+    MavenSession session = new MavenSession(container, MavenRepositorySystemUtils.newSession(), request, result);
+    session.setCurrentProject(project);
+    // noinspection ArraysAsListWithZeroOrOneArgument
+    session.setProjects(Arrays.asList(project));
+    return session;
+  }
+
+  /**
+   *
+   * @param goal
+   * @return
+   * @since 2.0
+   */
+  protected MojoExecution newMojoExecution(String goal) {
+    MojoDescriptor mojoDescriptor = mojoDescriptors.get(goal);
+    assertNotNull(String.format("The MojoDescriptor for the goal %s cannot be null.", goal), mojoDescriptor);
+    MojoExecution execution = new MojoExecution(mojoDescriptor);
+    finalizeMojoConfiguration(execution);
+    return execution;
+  }
+
+  // copy&paste from o.a.m.l.i.DefaultLifecycleExecutionPlanCalculator.finalizeMojoConfiguration(MojoExecution)
+  private void finalizeMojoConfiguration(MojoExecution mojoExecution) {
+    MojoDescriptor mojoDescriptor = mojoExecution.getMojoDescriptor();
+
+    Xpp3Dom executionConfiguration = mojoExecution.getConfiguration();
+    if (executionConfiguration == null) {
+      executionConfiguration = new Xpp3Dom("configuration");
+    }
+
+    Xpp3Dom defaultConfiguration = MojoDescriptorCreator.convert(mojoDescriptor);
+
+    Xpp3Dom finalConfiguration = new Xpp3Dom("configuration");
+
+    if (mojoDescriptor.getParameters() != null) {
+      for (Parameter parameter : mojoDescriptor.getParameters()) {
+        Xpp3Dom parameterConfiguration = executionConfiguration.getChild(parameter.getName());
+
+        if (parameterConfiguration == null) {
+          parameterConfiguration = executionConfiguration.getChild(parameter.getAlias());
+        }
+
+        Xpp3Dom parameterDefaults = defaultConfiguration.getChild(parameter.getName());
+
+        parameterConfiguration = Xpp3Dom.mergeXpp3Dom(parameterConfiguration, parameterDefaults, Boolean.TRUE);
+
+        if (parameterConfiguration != null) {
+          parameterConfiguration = new Xpp3Dom(parameterConfiguration, parameter.getName());
+
+          if (StringUtils.isEmpty(parameterConfiguration.getAttribute("implementation"))
+              && StringUtils.isNotEmpty(parameter.getImplementation())) {
+            parameterConfiguration.setAttribute("implementation", parameter.getImplementation());
+          }
+
+          finalConfiguration.addChild(parameterConfiguration);
+        }
+      }
+    }
+
+    mojoExecution.setConfiguration(finalConfiguration);
+  }
+
+  /**
+   * @param artifactId
+   * @param pom
+   * @return the plexus configuration
+   * @throws Exception
+   */
+  protected PlexusConfiguration extractPluginConfiguration(String artifactId, File pom) throws Exception {
+
+    try (Reader reader = ReaderFactory.newXmlReader(pom)) {
+      Xpp3Dom pomDom = Xpp3DomBuilder.build(reader);
+      return extractPluginConfiguration(artifactId, pomDom);
+    }
+  }
+
+  /**
+   * @param artifactId
+   * @param pomDom
+   * @return the plexus configuration
+   * @throws Exception
+   */
+  protected PlexusConfiguration extractPluginConfiguration(String artifactId, Xpp3Dom pomDom) throws Exception {
+    Xpp3Dom pluginConfigurationElement = null;
+
+    Xpp3Dom buildElement = pomDom.getChild("build");
+    if (buildElement != null) {
+      Xpp3Dom pluginsRootElement = buildElement.getChild("plugins");
+
+      if (pluginsRootElement != null) {
+        Xpp3Dom[] pluginElements = pluginsRootElement.getChildren();
+
+        for (Xpp3Dom pluginElement : pluginElements) {
+          String pluginElementArtifactId = pluginElement.getChild("artifactId").getValue();
+
+          if (pluginElementArtifactId.equals(artifactId)) {
+            pluginConfigurationElement = pluginElement.getChild("configuration");
+
+            break;
+          }
+        }
+
+        if (pluginConfigurationElement == null) {
+          throw new ConfigurationException(
+              "Cannot find a configuration element for a plugin with an " + "artifactId of " + artifactId + ".");
+        }
+      }
+    }
+
+    if (pluginConfigurationElement == null) {
+      throw new ConfigurationException(
+          "Cannot find a configuration element for a plugin with an artifactId of " + artifactId + ".");
+    }
+
+    return new XmlPlexusConfiguration(pluginConfigurationElement);
+  }
+
+  /**
+   * Configure the mojo
+   *
+   * @param mojo
+   * @param artifactId
+   * @param pom
+   * @return a Mojo instance
+   * @throws Exception
+   */
+  protected Mojo configureMojo(Mojo mojo, String artifactId, File pom) throws Exception {
+    validateContainerStatus();
+
+    PlexusConfiguration pluginConfiguration = extractPluginConfiguration(artifactId, pom);
+
+    ExpressionEvaluator evaluator = new ResolverExpressionEvaluatorStub();
+
+    configurator.configureComponent(mojo, pluginConfiguration, evaluator, getContainer().getContainerRealm());
+
+    return mojo;
+  }
+
+  /**
+   * Configure the mojo with the given plexus configuration
+   *
+   * @param mojo
+   * @param pluginConfiguration
+   * @return a Mojo instance
+   * @throws Exception
+   */
+  protected Mojo configureMojo(Mojo mojo, PlexusConfiguration pluginConfiguration) throws Exception {
+    validateContainerStatus();
+
+    ExpressionEvaluator evaluator = new ResolverExpressionEvaluatorStub();
+
+    configurator.configureComponent(mojo, pluginConfiguration, evaluator, getContainer().getContainerRealm());
+
+    return mojo;
+  }
+
+  /**
+   * Convenience method to obtain the value of a variable on a mojo that might not have a getter.
+   *
+   * NOTE: the caller is responsible for casting to to what the desired type is.
+   *
+   * @param object
+   * @param variable
+   * @return object value of variable
+   * @throws IllegalArgumentException
+   */
+  protected Object getVariableValueFromObject(Object object, String variable) throws IllegalAccessException {
+    Field field = ReflectionUtils.getFieldByNameIncludingSuperclasses(variable, object.getClass());
+
+    field.setAccessible(true);
+
+    return field.get(object);
+  }
+
+  /**
+   * Convenience method to obtain all variables and values from the mojo (including its superclasses)
+   *
+   * Note: the values in the map are of type Object so the caller is responsible for casting to desired types.
+   *
+   * @param object
+   * @return map of variable names and values
+   */
+  protected Map<String, Object> getVariablesAndValuesFromObject(Object object) throws IllegalAccessException {
+    return getVariablesAndValuesFromObject(object.getClass(), object);
+  }
+
+  /**
+   * Convenience method to obtain all variables and values from the mojo (including its superclasses)
+   *
+   * Note: the values in the map are of type Object so the caller is responsible for casting to desired types.
+   *
+   * @param clazz
+   * @param object
+   * @return map of variable names and values
+   */
+  protected Map<String, Object> getVariablesAndValuesFromObject(Class<?> clazz, Object object)
+      throws IllegalAccessException {
+    Map<String, Object> map = new HashMap<>();
+
+    Field[] fields = clazz.getDeclaredFields();
+
+    AccessibleObject.setAccessible(fields, true);
+
+    for (Field field : fields) {
+      map.put(field.getName(), field.get(object));
+    }
+
+    Class<?> superclass = clazz.getSuperclass();
+
+    if (!Object.class.equals(superclass)) {
+      map.putAll(getVariablesAndValuesFromObject(superclass, object));
+    }
+
+    return map;
+  }
+
+  /**
+   * Convenience method to set values to variables in objects that don't have setters
+   *
+   * @param object
+   * @param variable
+   * @param value
+   * @throws IllegalAccessException
+   */
+  protected void setVariableValueToObject(Object object, String variable, Object value) throws IllegalAccessException {
+    Field field = ReflectionUtils.getFieldByNameIncludingSuperclasses(variable, object.getClass());
+
+    field.setAccessible(true);
+
+    field.set(object, value);
+  }
+
+  /**
+   * sometimes the parent element might contain the correct value so generalize that access
+   *
+   * TODO find out where this is probably done elsewhere
+   *
+   * @param pluginPomDom
+   * @param element
+   * @return
+   * @throws Exception
+   */
+  private String resolveFromRootThenParent(Xpp3Dom pluginPomDom, String element) throws Exception {
+    Xpp3Dom elementDom = pluginPomDom.getChild(element);
+
+    // parent might have the group Id so resolve it
+    if (elementDom == null) {
+      Xpp3Dom pluginParentDom = pluginPomDom.getChild("parent");
+
+      if (pluginParentDom != null) {
+        elementDom = pluginParentDom.getChild(element);
+
+        if (elementDom == null) {
+          throw new Exception("unable to determine " + element);
+        }
+
+        return elementDom.getValue();
+      }
+
+      throw new Exception("unable to determine " + element);
+    }
+
+    return elementDom.getValue();
+  }
+
+  /**
+   * We should make sure this is called in each method that makes use of the container, otherwise we throw ugly NPE's
+   *
+   * crops up when the subclassing code defines the setUp method but doesn't call super.setUp()
+   *
+   * @throws Exception
+   */
+  private void validateContainerStatus() throws Exception {
+    if (getContainer() != null) {
+      return;
+    }
+
+    throw new Exception("container is null, make sure super.setUp() is called");
+  }
+}

--- a/src/test/java/org/mybatis/maven/mvnmigrate/AbstractMojoTestCase.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/AbstractMojoTestCase.java
@@ -5,7 +5,7 @@
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
@@ -279,7 +279,9 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
    *
    * @param goal
    * @param pluginPom
+   *
    * @return a Mojo instance
+   *
    * @throws Exception
    */
   protected Mojo lookupMojo(String goal, String pluginPom) throws Exception {
@@ -291,7 +293,9 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
    *
    * @param goal
    * @param pluginPom
+   *
    * @return a Mojo instance
+   *
    * @throws Exception
    */
   protected Mojo lookupEmptyMojo(String goal, String pluginPom) throws Exception {
@@ -303,7 +307,9 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
    *
    * @param goal
    * @param pom
+   *
    * @return a Mojo instance
+   *
    * @throws Exception
    */
   protected Mojo lookupMojo(String goal, File pom) throws Exception {
@@ -327,7 +333,9 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
    *
    * @param goal
    * @param pom
+   *
    * @return a Mojo instance
+   *
    * @throws Exception
    */
   protected Mojo lookupEmptyMojo(String goal, File pom) throws Exception {
@@ -357,7 +365,9 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
    * @param version
    * @param goal
    * @param pluginConfiguration
+   *
    * @return a Mojo instance
+   *
    * @throws Exception
    */
   protected Mojo lookupMojo(String groupId, String artifactId, String version, String goal,
@@ -388,11 +398,13 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
   }
 
   /**
-   *
    * @param project
    * @param goal
+   *
    * @return
+   *
    * @throws Exception
+   *
    * @since 2.0
    */
   protected Mojo lookupConfiguredMojo(MavenProject project, String goal) throws Exception {
@@ -400,12 +412,14 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
   }
 
   /**
-   *
    * @param session
    * @param execution
+   *
    * @return
+   *
    * @throws Exception
    * @throws ComponentConfigurationException
+   *
    * @since 2.0
    */
   protected Mojo lookupConfiguredMojo(MavenSession session, MojoExecution execution)
@@ -439,9 +453,10 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
   }
 
   /**
-   *
    * @param project
+   *
    * @return
+   *
    * @since 2.0
    */
   protected MavenSession newMavenSession(MavenProject project) {
@@ -456,9 +471,10 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
   }
 
   /**
-   *
    * @param goal
+   *
    * @return
+   *
    * @since 2.0
    */
   protected MojoExecution newMojoExecution(String goal) {
@@ -513,7 +529,9 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
   /**
    * @param artifactId
    * @param pom
+   *
    * @return the plexus configuration
+   *
    * @throws Exception
    */
   protected PlexusConfiguration extractPluginConfiguration(String artifactId, File pom) throws Exception {
@@ -527,7 +545,9 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
   /**
    * @param artifactId
    * @param pomDom
+   *
    * @return the plexus configuration
+   *
    * @throws Exception
    */
   protected PlexusConfiguration extractPluginConfiguration(String artifactId, Xpp3Dom pomDom) throws Exception {
@@ -571,7 +591,9 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
    * @param mojo
    * @param artifactId
    * @param pom
+   *
    * @return a Mojo instance
+   *
    * @throws Exception
    */
   protected Mojo configureMojo(Mojo mojo, String artifactId, File pom) throws Exception {
@@ -591,7 +613,9 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
    *
    * @param mojo
    * @param pluginConfiguration
+   *
    * @return a Mojo instance
+   *
    * @throws Exception
    */
   protected Mojo configureMojo(Mojo mojo, PlexusConfiguration pluginConfiguration) throws Exception {
@@ -605,13 +629,14 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
   }
 
   /**
-   * Convenience method to obtain the value of a variable on a mojo that might not have a getter.
-   *
-   * NOTE: the caller is responsible for casting to to what the desired type is.
+   * Convenience method to obtain the value of a variable on a mojo that might not have a getter. NOTE: the caller is
+   * responsible for casting to to what the desired type is.
    *
    * @param object
    * @param variable
+   *
    * @return object value of variable
+   *
    * @throws IllegalArgumentException
    */
   protected Object getVariableValueFromObject(Object object, String variable) throws IllegalAccessException {
@@ -623,11 +648,11 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
   }
 
   /**
-   * Convenience method to obtain all variables and values from the mojo (including its superclasses)
-   *
-   * Note: the values in the map are of type Object so the caller is responsible for casting to desired types.
+   * Convenience method to obtain all variables and values from the mojo (including its superclasses) Note: the values
+   * in the map are of type Object so the caller is responsible for casting to desired types.
    *
    * @param object
+   *
    * @return map of variable names and values
    */
   protected Map<String, Object> getVariablesAndValuesFromObject(Object object) throws IllegalAccessException {
@@ -635,12 +660,12 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
   }
 
   /**
-   * Convenience method to obtain all variables and values from the mojo (including its superclasses)
-   *
-   * Note: the values in the map are of type Object so the caller is responsible for casting to desired types.
+   * Convenience method to obtain all variables and values from the mojo (including its superclasses) Note: the values
+   * in the map are of type Object so the caller is responsible for casting to desired types.
    *
    * @param clazz
    * @param object
+   *
    * @return map of variable names and values
    */
   protected Map<String, Object> getVariablesAndValuesFromObject(Class<?> clazz, Object object)
@@ -670,6 +695,7 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
    * @param object
    * @param variable
    * @param value
+   *
    * @throws IllegalAccessException
    */
   protected void setVariableValueToObject(Object object, String variable, Object value) throws IllegalAccessException {
@@ -681,13 +707,14 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
   }
 
   /**
-   * sometimes the parent element might contain the correct value so generalize that access
-   *
-   * TODO find out where this is probably done elsewhere
+   * sometimes the parent element might contain the correct value so generalize that access TODO find out where this is
+   * probably done elsewhere
    *
    * @param pluginPomDom
    * @param element
+   *
    * @return
+   *
    * @throws Exception
    */
   private String resolveFromRootThenParent(Xpp3Dom pluginPomDom, String element) throws Exception {
@@ -715,7 +742,6 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
 
   /**
    * We should make sure this is called in each method that makes use of the container, otherwise we throw ugly NPE's
-   *
    * crops up when the subclassing code defines the setUp method but doesn't call super.setUp()
    *
    * @throws Exception

--- a/src/test/java/org/mybatis/maven/mvnmigrate/BootstrapCommandMojoTest.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/BootstrapCommandMojoTest.java
@@ -24,8 +24,8 @@ public class BootstrapCommandMojoTest extends AbstractMigrateTestCase {
   @SuppressWarnings("unchecked")
   @Test
   public void testBootstrapGoal() throws Exception {
-    AbstractCommandMojo<BootstrapCommand> mojo = (AbstractCommandMojo<BootstrapCommand>) rule.lookupMojo("bootstrap",
-        testPom);
+    AbstractCommandMojo<BootstrapCommand> mojo = (AbstractCommandMojo<BootstrapCommand>) testCase
+        .lookupMojo("bootstrap", testPom);
     Assertions.assertNotNull(mojo);
     mojo.execute();
   }

--- a/src/test/java/org/mybatis/maven/mvnmigrate/BootstrapCommandMojoTest.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/BootstrapCommandMojoTest.java
@@ -16,8 +16,8 @@
 package org.mybatis.maven.mvnmigrate;
 
 import org.apache.ibatis.migration.commands.BootstrapCommand;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BootstrapCommandMojoTest extends AbstractMigrateTestCase {
 

--- a/src/test/java/org/mybatis/maven/mvnmigrate/InitCommandMojoTest.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/InitCommandMojoTest.java
@@ -19,9 +19,9 @@ import java.io.File;
 
 import org.apache.ibatis.migration.commands.InitializeCommand;
 import org.apache.ibatis.migration.commands.NewCommand;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unchecked")
 public class InitCommandMojoTest extends AbstractMigrateTestCase {

--- a/src/test/java/org/mybatis/maven/mvnmigrate/InitCommandMojoTest.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/InitCommandMojoTest.java
@@ -19,14 +19,14 @@ import java.io.File;
 
 import org.apache.ibatis.migration.commands.InitializeCommand;
 import org.apache.ibatis.migration.commands.NewCommand;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 
 @SuppressWarnings("unchecked")
 public class InitCommandMojoTest extends AbstractMigrateTestCase {
 
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     initEnvironment();
   }

--- a/src/test/java/org/mybatis/maven/mvnmigrate/InitCommandMojoTest.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/InitCommandMojoTest.java
@@ -33,10 +33,10 @@ public class InitCommandMojoTest extends AbstractMigrateTestCase {
 
   @Test
   public void testNewGoal() throws Exception {
-    AbstractCommandMojo<NewCommand> mojo = (AbstractCommandMojo<NewCommand>) rule.lookupMojo("new", testPom);
+    AbstractCommandMojo<NewCommand> mojo = (AbstractCommandMojo<NewCommand>) testCase.lookupMojo("new", testPom);
     Assertions.assertNotNull(mojo);
-    rule.setVariableValueToObject(mojo, "repository", new File("target/init"));
-    rule.setVariableValueToObject(mojo, "description", "test_script");
+    testCase.setVariableValueToObject(mojo, "repository", new File("target/init"));
+    testCase.setVariableValueToObject(mojo, "description", "test_script");
     mojo.execute();
 
     final File newRep = new File("target/init/scripts");
@@ -46,10 +46,10 @@ public class InitCommandMojoTest extends AbstractMigrateTestCase {
   @Test
   public void testnewGoalRequiredValue() throws Exception {
     try {
-      AbstractCommandMojo<NewCommand> mojo = (AbstractCommandMojo<NewCommand>) rule.lookupMojo("new", testPom);
+      AbstractCommandMojo<NewCommand> mojo = (AbstractCommandMojo<NewCommand>) testCase.lookupMojo("new", testPom);
       Assertions.assertNotNull(mojo);
-      rule.setVariableValueToObject(mojo, "repository", new File("target/init"));
-      rule.setVariableValueToObject(mojo, "description", null);
+      testCase.setVariableValueToObject(mojo, "repository", new File("target/init"));
+      testCase.setVariableValueToObject(mojo, "description", null);
       mojo.execute();
       Assertions.fail();
     } catch (Exception e) {
@@ -59,10 +59,10 @@ public class InitCommandMojoTest extends AbstractMigrateTestCase {
   @Test
   public void testnewGoalSetEmptyValue() throws Exception {
     try {
-      AbstractCommandMojo<NewCommand> mojo = (AbstractCommandMojo<NewCommand>) rule.lookupMojo("new", testPom);
+      AbstractCommandMojo<NewCommand> mojo = (AbstractCommandMojo<NewCommand>) testCase.lookupMojo("new", testPom);
       Assertions.assertNotNull(mojo);
-      rule.setVariableValueToObject(mojo, "repository", new File("target/init"));
-      rule.setVariableValueToObject(mojo, "description", "");
+      testCase.setVariableValueToObject(mojo, "repository", new File("target/init"));
+      testCase.setVariableValueToObject(mojo, "description", "");
       mojo.execute();
     } catch (Exception e) {
     }
@@ -71,10 +71,10 @@ public class InitCommandMojoTest extends AbstractMigrateTestCase {
   @Test
   public void testnewGoalInitRepAlreadyExist() throws Exception {
     try {
-      AbstractCommandMojo<InitializeCommand> mojo = (AbstractCommandMojo<InitializeCommand>) rule.lookupMojo("init",
+      AbstractCommandMojo<InitializeCommand> mojo = (AbstractCommandMojo<InitializeCommand>) testCase.lookupMojo("init",
           testPom);
       Assertions.assertNotNull(mojo);
-      rule.setVariableValueToObject(mojo, "repository", new File("target/init"));
+      testCase.setVariableValueToObject(mojo, "repository", new File("target/init"));
       mojo.execute();
     } catch (Exception e) {
     }

--- a/src/test/java/org/mybatis/maven/mvnmigrate/MojoExtension.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/MojoExtension.java
@@ -17,32 +17,19 @@ package org.mybatis.maven.mvnmigrate;
 
 import java.io.File;
 
-import org.apache.maven.plugin.testing.MojoRule;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class MybatisMojoRule extends MojoRule {
+public class MojoExtension implements AfterEachCallback, BeforeEachCallback {
 
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  protected void before() throws Exception {
-    cleanup();
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  protected void after() {
-    try {
-      cleanup();
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-  }
+  // Make AbstractMojoTestCase concrete
+  protected AbstractMojoTestCase testCase = new AbstractMojoTestCase() {
+  };
 
   protected void cleanup() throws Exception {
-    final File initMigrationDbFolder = new File("target/init");
+    File initMigrationDbFolder;
+    initMigrationDbFolder = new File("target/init");
     if (initMigrationDbFolder.exists()) {
       deleteDir(initMigrationDbFolder);
     }
@@ -61,5 +48,17 @@ public class MybatisMojoRule extends MojoRule {
 
     // The directory is now empty so delete it
     return dir.delete();
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) throws Exception {
+    // Setup test case
+    testCase.setUp();
+    cleanup();
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) throws Exception {
+    cleanup();
   }
 }

--- a/src/test/java/org/mybatis/maven/mvnmigrate/PendingCommandMojoTest.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/PendingCommandMojoTest.java
@@ -39,30 +39,30 @@ public class PendingCommandMojoTest extends AbstractMigrateTestCase {
   }
 
   protected void runUpGoal() throws Exception {
-    AbstractCommandMojo<UpCommand> mojo = (AbstractCommandMojo<UpCommand>) rule.lookupMojo("up", testPom);
+    AbstractCommandMojo<UpCommand> mojo = (AbstractCommandMojo<UpCommand>) testCase.lookupMojo("up", testPom);
     Assertions.assertNotNull(mojo);
-    rule.setVariableValueToObject(mojo, "upSteps", null);
+    testCase.setVariableValueToObject(mojo, "upSteps", null);
     mojo.execute();
   }
 
   protected void runPendingGoal() throws Exception {
-    AbstractCommandMojo<PendingCommand> mojo = (AbstractCommandMojo<PendingCommand>) rule.lookupMojo("pending",
+    AbstractCommandMojo<PendingCommand> mojo = (AbstractCommandMojo<PendingCommand>) testCase.lookupMojo("pending",
         testPom);
     Assertions.assertNotNull(mojo);
     mojo.execute();
   }
 
   protected void runDownGoal() throws Exception {
-    AbstractCommandMojo<DownCommand> mojo = (AbstractCommandMojo<DownCommand>) rule.lookupMojo("down", testPom);
+    AbstractCommandMojo<DownCommand> mojo = (AbstractCommandMojo<DownCommand>) testCase.lookupMojo("down", testPom);
     Assertions.assertNotNull(mojo);
-    rule.setVariableValueToObject(mojo, "downSteps", "1");
+    testCase.setVariableValueToObject(mojo, "downSteps", "1");
     mojo.execute();
   }
 
   protected void runALLDownGoal() throws Exception {
-    AbstractCommandMojo<DownCommand> mojo = (AbstractCommandMojo<DownCommand>) rule.lookupMojo("down", testPom);
+    AbstractCommandMojo<DownCommand> mojo = (AbstractCommandMojo<DownCommand>) testCase.lookupMojo("down", testPom);
     Assertions.assertNotNull(mojo);
-    rule.setVariableValueToObject(mojo, "downSteps", "ALL");
+    testCase.setVariableValueToObject(mojo, "downSteps", "ALL");
     mojo.execute();
   }
 

--- a/src/test/java/org/mybatis/maven/mvnmigrate/PendingCommandMojoTest.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/PendingCommandMojoTest.java
@@ -18,14 +18,14 @@ package org.mybatis.maven.mvnmigrate;
 import org.apache.ibatis.migration.commands.DownCommand;
 import org.apache.ibatis.migration.commands.PendingCommand;
 import org.apache.ibatis.migration.commands.UpCommand;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 
 @SuppressWarnings("unchecked")
 public class PendingCommandMojoTest extends AbstractMigrateTestCase {
 
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     initEnvironment();
   }

--- a/src/test/java/org/mybatis/maven/mvnmigrate/PendingCommandMojoTest.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/PendingCommandMojoTest.java
@@ -18,9 +18,9 @@ package org.mybatis.maven.mvnmigrate;
 import org.apache.ibatis.migration.commands.DownCommand;
 import org.apache.ibatis.migration.commands.PendingCommand;
 import org.apache.ibatis.migration.commands.UpCommand;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unchecked")
 public class PendingCommandMojoTest extends AbstractMigrateTestCase {

--- a/src/test/java/org/mybatis/maven/mvnmigrate/ScriptCommandMojoTest.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/ScriptCommandMojoTest.java
@@ -18,8 +18,8 @@ package org.mybatis.maven.mvnmigrate;
 import java.io.File;
 
 import org.apache.ibatis.migration.commands.ScriptCommand;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unchecked")
 public class ScriptCommandMojoTest extends AbstractMigrateTestCase {

--- a/src/test/java/org/mybatis/maven/mvnmigrate/ScriptCommandMojoTest.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/ScriptCommandMojoTest.java
@@ -26,40 +26,44 @@ public class ScriptCommandMojoTest extends AbstractMigrateTestCase {
 
   @Test
   public void testScriptGoal() throws Exception {
-    AbstractCommandMojo<ScriptCommand> mojo = (AbstractCommandMojo<ScriptCommand>) rule.lookupMojo("script", testPom);
+    AbstractCommandMojo<ScriptCommand> mojo = (AbstractCommandMojo<ScriptCommand>) testCase.lookupMojo("script",
+        testPom);
     Assertions.assertNotNull(mojo);
-    rule.setVariableValueToObject(mojo, "v1", "20100400000001");
-    rule.setVariableValueToObject(mojo, "v2", "20100400000003");
+    testCase.setVariableValueToObject(mojo, "v1", "20100400000001");
+    testCase.setVariableValueToObject(mojo, "v2", "20100400000003");
     mojo.execute();
   }
 
   @Test
   public void testScriptToFileGoal() throws Exception {
-    AbstractCommandMojo<ScriptCommand> mojo = (AbstractCommandMojo<ScriptCommand>) rule.lookupMojo("script", testPom);
+    AbstractCommandMojo<ScriptCommand> mojo = (AbstractCommandMojo<ScriptCommand>) testCase.lookupMojo("script",
+        testPom);
     Assertions.assertNotNull(mojo);
-    rule.setVariableValueToObject(mojo, "v1", "20100400000001");
-    rule.setVariableValueToObject(mojo, "v2", "20100400000003");
-    rule.setVariableValueToObject(mojo, "output", new File("target/script_20100400000001-20100400000003.sql"));
+    testCase.setVariableValueToObject(mojo, "v1", "20100400000001");
+    testCase.setVariableValueToObject(mojo, "v2", "20100400000003");
+    testCase.setVariableValueToObject(mojo, "output", new File("target/script_20100400000001-20100400000003.sql"));
     mojo.execute();
     Assertions.assertTrue(new File("target/script_20100400000001-20100400000003.sql").exists());
   }
 
   @Test
   public void testScriptPending() throws Exception {
-    AbstractCommandMojo<ScriptCommand> mojo = (AbstractCommandMojo<ScriptCommand>) rule.lookupMojo("script", testPom);
+    AbstractCommandMojo<ScriptCommand> mojo = (AbstractCommandMojo<ScriptCommand>) testCase.lookupMojo("script",
+        testPom);
     Assertions.assertNotNull(mojo);
-    rule.setVariableValueToObject(mojo, "v1", "pending");
-    rule.setVariableValueToObject(mojo, "output", new File("target/script_pending.sql"));
+    testCase.setVariableValueToObject(mojo, "v1", "pending");
+    testCase.setVariableValueToObject(mojo, "output", new File("target/script_pending.sql"));
     mojo.execute();
     Assertions.assertTrue(new File("target/script_pending.sql").exists());
   }
 
   @Test
   public void testScriptPendingUndo() throws Exception {
-    AbstractCommandMojo<ScriptCommand> mojo = (AbstractCommandMojo<ScriptCommand>) rule.lookupMojo("script", testPom);
+    AbstractCommandMojo<ScriptCommand> mojo = (AbstractCommandMojo<ScriptCommand>) testCase.lookupMojo("script",
+        testPom);
     Assertions.assertNotNull(mojo);
-    rule.setVariableValueToObject(mojo, "v1", "pending_undo");
-    rule.setVariableValueToObject(mojo, "output", new File("target/script_pending_undo.sql"));
+    testCase.setVariableValueToObject(mojo, "v1", "pending_undo");
+    testCase.setVariableValueToObject(mojo, "output", new File("target/script_pending_undo.sql"));
     mojo.execute();
     Assertions.assertTrue(new File("target/script_pending_undo.sql").exists());
   }

--- a/src/test/java/org/mybatis/maven/mvnmigrate/StatusCommandMojoTest.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/StatusCommandMojoTest.java
@@ -24,7 +24,8 @@ public class StatusCommandMojoTest extends AbstractMigrateTestCase {
   @SuppressWarnings("unchecked")
   @Test
   public void testStatusGoal() throws Exception {
-    AbstractCommandMojo<StatusCommand> mojo = (AbstractCommandMojo<StatusCommand>) rule.lookupMojo("status", testPom);
+    AbstractCommandMojo<StatusCommand> mojo = (AbstractCommandMojo<StatusCommand>) testCase.lookupMojo("status",
+        testPom);
     Assertions.assertNotNull(mojo);
     mojo.execute();
   }

--- a/src/test/java/org/mybatis/maven/mvnmigrate/StatusCommandMojoTest.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/StatusCommandMojoTest.java
@@ -16,8 +16,8 @@
 package org.mybatis.maven.mvnmigrate;
 
 import org.apache.ibatis.migration.commands.StatusCommand;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class StatusCommandMojoTest extends AbstractMigrateTestCase {
 

--- a/src/test/java/org/mybatis/maven/mvnmigrate/VersionCommandMojoTest.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/VersionCommandMojoTest.java
@@ -31,25 +31,25 @@ public class VersionCommandMojoTest extends AbstractMigrateTestCase {
   }
 
   protected void runUpGoal() throws Exception {
-    AbstractCommandMojo<UpCommand> mojo = (AbstractCommandMojo<UpCommand>) rule.lookupMojo("up", testPom);
+    AbstractCommandMojo<UpCommand> mojo = (AbstractCommandMojo<UpCommand>) testCase.lookupMojo("up", testPom);
     Assertions.assertNotNull(mojo);
-    rule.setVariableValueToObject(mojo, "upSteps", "1");
+    testCase.setVariableValueToObject(mojo, "upSteps", "1");
     mojo.execute();
   }
 
   protected void runVersionGoal() throws Exception {
-    AbstractCommandMojo<VersionCommand> mojo = (AbstractCommandMojo<VersionCommand>) rule.lookupMojo("version",
+    AbstractCommandMojo<VersionCommand> mojo = (AbstractCommandMojo<VersionCommand>) testCase.lookupMojo("version",
         testPom);
     Assertions.assertNotNull(mojo);
-    rule.setVariableValueToObject(mojo, "version", "20100400000003");
+    testCase.setVariableValueToObject(mojo, "version", "20100400000003");
     mojo.execute();
   }
 
   protected void runVersionDownGoal() throws Exception {
-    AbstractCommandMojo<VersionCommand> mojo = (AbstractCommandMojo<VersionCommand>) rule.lookupMojo("version",
+    AbstractCommandMojo<VersionCommand> mojo = (AbstractCommandMojo<VersionCommand>) testCase.lookupMojo("version",
         testPom);
     Assertions.assertNotNull(mojo);
-    rule.setVariableValueToObject(mojo, "version", "20100400000001");
+    testCase.setVariableValueToObject(mojo, "version", "20100400000001");
     mojo.execute();
   }
 

--- a/src/test/java/org/mybatis/maven/mvnmigrate/VersionCommandMojoTest.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/VersionCommandMojoTest.java
@@ -17,8 +17,8 @@ package org.mybatis.maven.mvnmigrate;
 
 import org.apache.ibatis.migration.commands.UpCommand;
 import org.apache.ibatis.migration.commands.VersionCommand;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unchecked")
 public class VersionCommandMojoTest extends AbstractMigrateTestCase {


### PR DESCRIPTION
Finishing off work from 2018 and number of failed attempts since to make this happen.  In order to make this real, had to copy entire class from Maven Plugin Testing [here](https://github.com/apache/maven-plugin-testing/) for [AbstractMojoTestCase](https://github.com/apache/maven-plugin-testing/blob/master/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/AbstractMojoTestCase.java) and simply a direct call to set variable from [MojoRule](https://github.com/apache/maven-plugin-testing/blob/master/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/MojoRule.java) along with modified usage of the rule as direct test case with adjustment through extention.  While not ideal, lack of maven getting the harness to junit 5 and not much on mailing lists to be heard on the subject, this felt like easiest way to finish this off given all other projects to my knowledge in Mybatis are on junit 5 now.