### PR TITLE
Copy more maven testing module to support maven 3 still with junit 5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         cache: [maven]
         distribution: [temurin]
-        java: [11, 17, 21, 22, 23-ea]
+        java: [11, 17, 21, 22, 23-ea, 24-ea]
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
       max-parallel: 4

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,10 @@
   </distributionManagement>
 
   <properties>
+    <!-- Java Usage -->
+    <java.version>8</java.version>
+    <java.release.version>8</java.release.version>
+
     <findbugs.onlyAnalyze>org.mybatis.maven.mvnmigrate.*</findbugs.onlyAnalyze>
     <module.name>org.mybatis.maven.migrations</module.name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
     <version>44</version>
-    <relativePath/>
+    <relativePath />
   </parent>
 
   <groupId>org.mybatis.maven</groupId>
@@ -32,11 +32,9 @@
   <packaging>maven-plugin</packaging>
 
   <name>MyBatis Migrations Maven plugin</name>
-  <description>
-    Migration-plugin is a Apache Maven 3 plugin that aims to integrate into the maven life cycle,
+  <description>Migration-plugin is a Apache Maven 3 plugin that aims to integrate into the maven life cycle,
     the myBatis 3 Migration tool. MyBatis 3 Migration Schema is a tool that helps you to manage database
-    schema changes.
-  </description>
+    schema changes.</description>
   <url>https://www.mybatis.org/migrations-maven-plugin/</url>
 
   <scm>
@@ -351,7 +349,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore/>
+                        <ignore />
                       </action>
                     </pluginExecution>
                     <pluginExecution>
@@ -364,7 +362,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore/>
+                        <ignore />
                       </action>
                     </pluginExecution>
                   </pluginExecutions>

--- a/src/main/java/org/mybatis/maven/mvnmigrate/CheckCommandMojo.java
+++ b/src/main/java/org/mybatis/maven/mvnmigrate/CheckCommandMojo.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2010-2022 the original author or authors.
+ *    Copyright 2010-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ public final class CheckCommandMojo extends StatusCommandMojo {
     init();
 
     if (getCommand() instanceof StatusCommand) {
-      StatusCommand command = (StatusCommand) getCommand();
+      StatusCommand command = getCommand();
       command.execute();
       StatusOperation operation = command.getOperation();
       List<Change> changes = operation.getCurrentStatus();

--- a/src/main/java/org/mybatis/maven/mvnmigrate/PendingCommandMojo.java
+++ b/src/main/java/org/mybatis/maven/mvnmigrate/PendingCommandMojo.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2010-2022 the original author or authors.
+ *    Copyright 2010-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,9 +25,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 @Mojo(name = "pending")
 public final class PendingCommandMojo extends AbstractCommandMojo<PendingCommand> {
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   protected PendingCommand createCommandClass(SelectedOptions options) {
     return new PendingCommand(options);

--- a/src/main/java/org/mybatis/maven/mvnmigrate/report/StatusCommandReportMojo.java
+++ b/src/main/java/org/mybatis/maven/mvnmigrate/report/StatusCommandReportMojo.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2010-2022 the original author or authors.
+ *    Copyright 2010-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -133,11 +133,11 @@ public final class StatusCommandReportMojo extends AbstractMavenReport {
       return;
     }
 
-    Map<MavenProject, List<Change>> aggregateReport = new HashMap<MavenProject, List<Change>>();
+    Map<MavenProject, List<Change>> aggregateReport = new HashMap<>();
 
     for (MavenProject mavenProject : reactorProjects) {
 
-      Map<String, ReportPlugin> reportPluginMap = mavenProject.getReporting().getReportPluginsAsMap();
+      Map<String, ReportPlugin> reportPluginMap = mavenProject.getModel().getReporting().getReportPluginsAsMap();
       ReportPlugin plug = reportPluginMap.get(getBundle(locale).getString("migration.plugin.key"));
 
       Xpp3Dom configurationDom = (Xpp3Dom) plug.getConfiguration();

--- a/src/main/java/org/mybatis/maven/mvnmigrate/util/MavenOutputStream.java
+++ b/src/main/java/org/mybatis/maven/mvnmigrate/util/MavenOutputStream.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2010-2022 the original author or authors.
+ *    Copyright 2010-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public class MavenOutputStream extends OutputStream {
   @Override
   public void write(byte[] b, int off, int len) throws IOException {
     for (int i = off; i < len; i++) {
-      write((int) b[i]);
+      write(b[i]);
     }
   }
 

--- a/src/test/java/org/mybatis/maven/mvnmigrate/AbstractMigrateTestCase.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/AbstractMigrateTestCase.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2010-2022 the original author or authors.
+ *    Copyright 2010-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.apache.ibatis.migration.commands.InitializeCommand;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mybatis.maven.testing.AbstractMojoTestCase;
 
 @ExtendWith(MojoExtension.class)
 public abstract class AbstractMigrateTestCase {

--- a/src/test/java/org/mybatis/maven/mvnmigrate/MojoExtension.java
+++ b/src/test/java/org/mybatis/maven/mvnmigrate/MojoExtension.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2010-2022 the original author or authors.
+ *    Copyright 2010-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.io.File;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mybatis.maven.testing.AbstractMojoTestCase;
 
 public class MojoExtension implements AfterEachCallback, BeforeEachCallback {
 
@@ -27,7 +28,7 @@ public class MojoExtension implements AfterEachCallback, BeforeEachCallback {
   protected AbstractMojoTestCase testCase = new AbstractMojoTestCase() {
   };
 
-  protected void cleanup() throws Exception {
+  protected void cleanup() {
     File initMigrationDbFolder;
     initMigrationDbFolder = new File("target/init");
     if (initMigrationDbFolder.exists()) {

--- a/src/test/java/org/mybatis/maven/testing/AbstractMojoTestCase.java
+++ b/src/test/java/org/mybatis/maven/testing/AbstractMojoTestCase.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2010-2023 the original author or authors.
+ *    Copyright 2010-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.mybatis.maven.mvnmigrate;
+package org.mybatis.maven.testing;
 
 import com.google.inject.Module;
 
@@ -70,8 +70,6 @@ import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.Parameter;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugin.descriptor.PluginDescriptorBuilder;
-import org.apache.maven.plugin.testing.ConfigurationException;
-import org.apache.maven.plugin.testing.ResolverExpressionEvaluatorStub;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.codehaus.plexus.ContainerConfiguration;
@@ -82,7 +80,6 @@ import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.PlexusContainerException;
 import org.codehaus.plexus.PlexusTestCase;
 import org.codehaus.plexus.classworlds.ClassWorld;
-import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 import org.codehaus.plexus.component.configurator.ComponentConfigurator;
 import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
 import org.codehaus.plexus.component.repository.ComponentDescriptor;
@@ -99,7 +96,8 @@ import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 
 /**
  * Mybatis: Borrowed from 'https://github.com/apache/maven-plugin-testing/blob/master/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/AbstractMojoTestCase.java'
- * Reason: Too restrictive to use directly for junit 5.  Only changes were to add imports after inclusion from maven's test harness.
+ * Reason: Too restrictive to use directly for junit 5.
+ * Changes: Imports added, method access expanded, removed some left over junk code
  * Git: From release 4.0.0-alpha-2
  */
 
@@ -146,9 +144,8 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
    * we are going to try and make an instance of the localrespository and assign that to either the project stub or into
    * the mojo directly with injection...not sure yet though.
    */
-  // private MavenProjectBuilder projectBuilder;
   @Override
-  protected void setUp() throws Exception {
+  public void setUp() throws Exception {
     assertTrue("Maven 3.2.4 or better is required",
         MAVEN_VERSION == null || new DefaultArtifactVersion("3.2.3").compareTo(MAVEN_VERSION) < 0);
 
@@ -311,7 +308,7 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
    *
    * @throws Exception
    */
-  protected <T extends Mojo> T lookupMojo(String goal, File pom) throws Exception {
+  public <T extends Mojo> T lookupMojo(String goal, File pom) throws Exception {
     File pluginPom = new File(getBasedir(), "pom.xml");
 
     Xpp3Dom pluginPomDom = Xpp3DomBuilder.build(ReaderFactory.newXmlReader(pluginPom));
@@ -351,11 +348,6 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
     return lookupMojo(groupId, artifactId, version, goal, null);
   }
 
-  /*
-   * protected Mojo lookupMojo( String groupId, String artifactId, String version, String goal, File pom ) throws
-   * Exception { PlexusConfiguration pluginConfiguration = extractPluginConfiguration( artifactId, pom ); return
-   * lookupMojo( groupId, artifactId, version, goal, pluginConfiguration ); }
-   */
   /**
    * lookup the mojo while we have all of the relavent information
    *
@@ -378,10 +370,6 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
     T mojo = (T) lookup(Mojo.class, groupId + ":" + artifactId + ":" + version + ":" + goal);
 
     if (pluginConfiguration != null) {
-      /*
-       * requires v10 of plexus container for lookup on expression evaluator ExpressionEvaluator evaluator =
-       * (ExpressionEvaluator) getContainer().lookup( ExpressionEvaluator.ROLE, "stub-evaluator" );
-       */
       ExpressionEvaluator evaluator = new ResolverExpressionEvaluatorStub();
 
       configurator.configureComponent(mojo, pluginConfiguration, evaluator, getContainer().getContainerRealm());
@@ -411,12 +399,10 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
    * @return
    *
    * @throws Exception
-   * @throws ComponentConfigurationException
    *
    * @since 2.0
    */
-  protected <T extends Mojo> T lookupConfiguredMojo(MavenSession session, MojoExecution execution)
-      throws Exception, ComponentConfigurationException {
+  protected <T extends Mojo> T lookupConfiguredMojo(MavenSession session, MojoExecution execution) throws Exception {
     MavenProject project = session.getCurrentProject();
     MojoDescriptor mojoDescriptor = execution.getMojoDescriptor();
 
@@ -690,7 +676,7 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
    *
    * @throws IllegalAccessException
    */
-  protected <T> void setVariableValueToObject(Object object, String variable, T value) throws IllegalAccessException {
+  public <T> void setVariableValueToObject(Object object, String variable, T value) throws IllegalAccessException {
     Field field = ReflectionUtils.getFieldByNameIncludingSuperclasses(variable, object.getClass());
 
     field.setAccessible(true);
@@ -699,8 +685,9 @@ public abstract class AbstractMojoTestCase extends PlexusTestCase {
   }
 
   /**
-   * sometimes the parent element might contain the correct value so generalize that access TODO find out where this is
-   * probably done elsewhere
+   * Sometimes the parent element might contain the correct value so generalize that access.
+   * <p>
+   * TODO find out where this is probably done elsewhere
    *
    * @param pluginPomDom
    * @param element

--- a/src/test/java/org/mybatis/maven/testing/ConfigurationException.java
+++ b/src/test/java/org/mybatis/maven/testing/ConfigurationException.java
@@ -1,0 +1,76 @@
+/*
+ *    Copyright 2010-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.mybatis.maven.testing;
+
+/**
+ * Mybatis: Borrowed from 'https://github.com/apache/maven-plugin-testing/blob/master/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/ConfiguationException.java'
+ * Reason: Removed from release 4.0.0-beta-1 and we need to have junit 5 support.  Maven dropped maven 3 support here!
+ * Git: From release 4.0.0-alpha-2
+ */
+
+/**
+ * ConfigurationException
+ *
+ * @author jesse
+ */
+public class ConfigurationException extends Exception {
+  /** serialVersionUID */
+  static final long serialVersionUID = -6180939638742159065L;
+
+  /**
+   * @param message
+   *          The detailed message.
+   */
+  public ConfigurationException(String message) {
+    super(message);
+  }
+
+  /**
+   * @param cause
+   *          The detailed cause.
+   */
+  public ConfigurationException(Throwable cause) {
+    super(cause);
+  }
+
+  /**
+   * @param message
+   *          The detailed message.
+   * @param cause
+   *          The detailed cause.
+   */
+  public ConfigurationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/test/java/org/mybatis/maven/testing/ResolverExpressionEvaluatorStub.java
+++ b/src/test/java/org/mybatis/maven/testing/ResolverExpressionEvaluatorStub.java
@@ -1,0 +1,131 @@
+/*
+ *    Copyright 2010-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.mybatis.maven.testing;
+
+import java.io.File;
+
+import org.apache.maven.artifact.repository.MavenArtifactRepository;
+import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
+import org.codehaus.plexus.PlexusTestCase;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+
+/**
+ * Mybatis: Borrowed from 'https://github.com/apache/maven-plugin-testing/blob/master/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/ConfiguationException.java'
+ * Reason: Removed from release 4.0.0-beta-1 and we need to have junit 5 support.  Maven dropped maven 3 support here!
+ * Git: From release 4.0.0-alpha-2
+ */
+
+/**
+ * Stub for {@link ExpressionEvaluator}
+ *
+ * @author jesse
+ */
+public class ResolverExpressionEvaluatorStub implements ExpressionEvaluator {
+  /** {@inheritDoc} */
+  @Override
+  public Object evaluate(String expr) throws ExpressionEvaluationException {
+
+    Object value = null;
+
+    if (expr == null) {
+      return null;
+    }
+
+    String expression = stripTokens(expr);
+
+    if (expression.equals(expr)) {
+      int index = expr.indexOf("${");
+      if (index >= 0) {
+        int lastIndex = expr.indexOf("}", index);
+        if (lastIndex >= 0) {
+          String retVal = expr.substring(0, index);
+
+          if (index > 0 && expr.charAt(index - 1) == '$') {
+            retVal += expr.substring(index + 1, lastIndex + 1);
+          } else {
+            retVal += evaluate(expr.substring(index, lastIndex + 1));
+          }
+
+          retVal += evaluate(expr.substring(lastIndex + 1));
+          return retVal;
+        }
+      }
+
+      // Was not an expression
+      if (expression.indexOf("$$") > -1) {
+        return expression.replaceAll("\\$\\$", "\\$");
+      }
+    }
+
+    if ("basedir".equals(expression) || "project.basedir".equals(expression)) {
+      return PlexusTestCase.getBasedir();
+    } else if (expression.startsWith("basedir") || expression.startsWith("project.basedir")) {
+      int pathSeparator = expression.indexOf("/");
+
+      if (pathSeparator > 0) {
+        value = PlexusTestCase.getBasedir() + expression.substring(pathSeparator);
+      } else {
+        System.out.println("Got expression '" + expression + "' that was not recognised");
+      }
+      return value;
+    } else if ("localRepository".equals(expression)) {
+      File localRepo = new File(PlexusTestCase.getBasedir(), "target/local-repo");
+      return new MavenArtifactRepository("localRepository", "file://" + localRepo.getAbsolutePath(),
+          new DefaultRepositoryLayout(), null, null);
+    } else {
+      return expr;
+    }
+  }
+
+  private String stripTokens(String expr) {
+    if (expr.startsWith("${") && expr.indexOf("}") == expr.length() - 1) {
+      expr = expr.substring(2, expr.length() - 1);
+    }
+
+    return expr;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public File alignToBaseDirectory(File file) {
+    if (file.getAbsolutePath().startsWith(PlexusTestCase.getBasedir())) {
+      return file;
+    } else if (file.isAbsolute()) {
+      return file;
+    } else {
+      return new File(PlexusTestCase.getBasedir(), file.getPath());
+    }
+  }
+}

--- a/src/test/java/org/mybatis/maven/testing/package-info.java
+++ b/src/test/java/org/mybatis/maven/testing/package-info.java
@@ -1,0 +1,20 @@
+/*
+ *    Copyright 2010-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+/**
+ * Code borrowed from Maven Plugin Testing from 4.0.0-alpha-2 in order to support maven 3 with junit 5. Maven has since
+ * deleted all maven 3 support leaving no real option here.
+ */
+package org.mybatis.maven.testing;


### PR DESCRIPTION
Maven dropped maven 3 support from ongoing work leaving any plugin using this not working with junit 5.  Copied additional classes they deleted and made an entire package out of the maven code so we can continue to be up to date and work.